### PR TITLE
Split journey action into its parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Include `stageprompt.js` in your HTML, and set it up by providing a function to 
 Or configure the callback yourself. In the example below an event is sent to Google Analytics for each stage.
 
     $(function () {
-      GOVUK.performance.stageprompt.setup(function (journeyStage) {
-        _gaq.push(['_trackEvent', journeyStage , 'n/a', undefined, undefined, true]);
-      })
+      GOVUK.performance.stageprompt.setup(function (category, event, label) {
+        _gaq.push(['_trackEvent', category, event, label, undefined, true]);
+      });
     });
 
 ## Sending events when a user reaches a page in your user journey
@@ -52,9 +52,9 @@ user is redirected back to GOV.UK at `/pay-register-birth-abroad/done`:
         [...]
     </div>
 
-## Sending events when a user uses help buttons
+## Sending events when a user clicks on a page element
 
-Add `data-journey-helper` attributes to the HTML for your help link or button. This will only work if the user is
+Add `data-journey-click` attributes to the element clicked by the user. This will only work if the user is
 not sent to a new page on click. Example:
 
-    <a class="help-button" href="#" data-journey-helper="stage:journey:helper">See more info...</a>
+    <a class="help-button" href="#" data-journey-click="stage:help:info">See more info...</a>

--- a/script/stageprompt.js
+++ b/script/stageprompt.js
@@ -3,9 +3,10 @@ var GOVUK = GOVUK || {};
 GOVUK.performance = GOVUK.performance || {};
 
 GOVUK.performance.stageprompt = (function () {
-  var setup, setupForGoogleAnalytics;
 
-  var splitAction = function (action) {
+  var setup, setupForGoogleAnalytics, splitAction;
+
+  splitAction = function (action) {
     var parts = action.split(':');
     if (parts.length <= 3) return parts;
     return [parts.shift(), parts.shift(), parts.join(':')];
@@ -21,7 +22,7 @@ GOVUK.performance.stageprompt = (function () {
     
     if (journeyHelpers.length) {
       journeyHelpers.on('click', function (event) {
-        analyticsCallback($(this).data('journey-helper'));
+        analyticsCallback.apply(null, splitAction($(this).data('journey-helper')));
       });
     }
   };

--- a/script/stageprompt.js
+++ b/script/stageprompt.js
@@ -5,11 +5,18 @@ GOVUK.performance = GOVUK.performance || {};
 GOVUK.performance.stageprompt = (function () {
   var setup, setupForGoogleAnalytics;
 
+  var splitAction = function (action) {
+    var parts = action.split(':');
+    if (parts.length <= 3) return parts;
+    return [parts.shift(), parts.shift(), parts.join(':')];
+  };
+
   setup = function (analyticsCallback) {
     var journeyStage = $('[data-journey]').attr('data-journey'),
         journeyHelpers = $('[data-journey-helper]');
+
     if (journeyStage) {
-      analyticsCallback(journeyStage);
+      analyticsCallback.apply(null, splitAction(journeyStage));
     }
     
     if (journeyHelpers.length) {

--- a/script/stageprompt.js
+++ b/script/stageprompt.js
@@ -37,6 +37,6 @@ GOVUK.performance.stageprompt = (function () {
   };
 }());
 
-GOVUK.performance.sendGoogleAnalyticsEvent = function (action) {
-  _gaq.push(['_trackEvent', 'stagePrompt', action, undefined, undefined, true]);
+GOVUK.performance.sendGoogleAnalyticsEvent = function (category, event, label) {
+  _gaq.push(['_trackEvent', category, event, label, undefined, true]);
 };

--- a/script/stageprompt.js
+++ b/script/stageprompt.js
@@ -14,7 +14,7 @@ GOVUK.performance.stageprompt = (function () {
 
   setup = function (analyticsCallback) {
     var journeyStage = $('[data-journey]').attr('data-journey'),
-        journeyHelpers = $('[data-journey-helper]');
+        journeyHelpers = $('[data-journey-click]');
 
     if (journeyStage) {
       analyticsCallback.apply(null, splitAction(journeyStage));
@@ -22,7 +22,7 @@ GOVUK.performance.stageprompt = (function () {
     
     if (journeyHelpers.length) {
       journeyHelpers.on('click', function (event) {
-        analyticsCallback.apply(null, splitAction($(this).data('journey-helper')));
+        analyticsCallback.apply(null, splitAction($(this).data('journey-click')));
       });
     }
   };

--- a/spec/javascripts/analyticsCallbacksSpec.js
+++ b/spec/javascripts/analyticsCallbacksSpec.js
@@ -1,31 +1,41 @@
 describe("Google Analytics callback", function () {
-  
-  _gaq = [];
-  
+
   beforeEach(function () {
+    _gaq = { push: function() {} };
     spyOn(_gaq, 'push');
   });
-  
+
   it("should push an event onto the google analytics que", function () {
     GOVUK.performance.sendGoogleAnalyticsEvent('test');
     
     expect(_gaq.push).toHaveBeenCalled();
-    expect(_gaq.push.argsForCall[0][0][0]).toEqual('_trackEvent');
+    expect(method(_gaq.push.argsForCall)).toEqual('_trackEvent');
+  });
+
+  it("should use arguments as category, event, label", function() {
+    GOVUK.performance.sendGoogleAnalyticsEvent('arg-1', 'arg-2', 'arg-3');
+
+    expect(_gaq.push).toHaveBeenCalled();
+    expect(category(_gaq.push.argsForCall)).toEqual('arg-1');
+    expect(action(_gaq.push.argsForCall)).toEqual('arg-2');
+    expect(label(_gaq.push.argsForCall)).toEqual('arg-3');
   });
   
   it("should use sensible default values... eg. non interaction events so as not to mess with bounce rate", function () {
     GOVUK.performance.sendGoogleAnalyticsEvent('test event')
-    
-    var category = _gaq.push.argsForCall[0][0][1],
-        action = _gaq.push.argsForCall[0][0][2],
-        label = _gaq.push.argsForCall[0][0][3],
-        value = _gaq.push.argsForCall[0][0][4],
-        nonInteraction = _gaq.push.argsForCall[0][0][5];
-    
-    expect(category).toEqual('stagePrompt');
-    expect(action).toEqual('test event');
-    expect(label).toBe(undefined);
-    expect(value).toBe(undefined);
-    expect(nonInteraction).toEqual(true);
+
+    expect(category(_gaq.push.argsForCall)).toEqual('test event');
+    expect(action(_gaq.push.argsForCall)).toEqual(undefined);
+    expect(label(_gaq.push.argsForCall)).toBe(undefined);
+    expect(value(_gaq.push.argsForCall)).toBe(undefined);
+    expect(nonInteraction(_gaq.push.argsForCall)).toEqual(true);
   })
+
+  function method(args)         { return args[0][0][0]; }
+  function category(args)       { return args[0][0][1]; }
+  function action(args)         { return args[0][0][2]; }
+  function label(args)          { return args[0][0][3]; }
+  function value(args)          { return args[0][0][4]; }
+  function nonInteraction(args) { return args[0][0][5]; }
+
 });

--- a/spec/javascripts/stagepromptSpec.js
+++ b/spec/javascripts/stagepromptSpec.js
@@ -98,7 +98,7 @@ describe("stageprompt", function () {
     });
   });
   
-  describe("sending events for helper tags", function () {
+  describe("sending events for click actions", function () {
     beforeEach(function () {
       analyticsCallback = jasmine.createSpy();
       $("<div id='sandbox'></div>").appendTo('body');
@@ -109,7 +109,7 @@ describe("stageprompt", function () {
     });
     
     it("should send an event when a help link is clicked", function () {
-      $('#sandbox').attr('data-journey-helper', 'test-journey:stuff:help');
+      $('#sandbox').attr('data-journey-click', 'test-journey:stuff:help');
       GOVUK.performance.stageprompt.setup(analyticsCallback);
       
       $('#sandbox').click();
@@ -118,8 +118,8 @@ describe("stageprompt", function () {
     });
     
     it("should send events for multiple help elements on the same page", function () {
-      $('#sandbox').append('<a href="#" id="1" data-journey-helper="a">foo</a>');
-      $('#sandbox').append('<a href="#" id="2" data-journey-helper="b">bar</a>');
+      $('#sandbox').append('<a href="#" id="1" data-journey-click="a">foo</a>');
+      $('#sandbox').append('<a href="#" id="2" data-journey-click="b">bar</a>');
       
       GOVUK.performance.stageprompt.setup(analyticsCallback);
       $('#1').click();
@@ -130,7 +130,7 @@ describe("stageprompt", function () {
     });
     
     it("should send one event per click on tagged item", function () {
-      $('#sandbox').append('<a href="#" id="1" data-journey-helper="a">foo</a>');  
+      $('#sandbox').append('<a href="#" id="1" data-journey-click="a">foo</a>');  
       GOVUK.performance.stageprompt.setup(analyticsCallback);
     
       $('#1').click();

--- a/spec/javascripts/stagepromptSpec.js
+++ b/spec/javascripts/stagepromptSpec.js
@@ -37,7 +37,7 @@ describe("stageprompt", function () {
       var spy = jasmine.createSpy();
       GOVUK.performance.stageprompt.setup(analyticsCallback);
 
-      expect(analyticsCallback).toHaveBeenCalledWith("test-journey:someStage");
+      expect(analyticsCallback).toHaveBeenCalledWith("test-journey", "someStage");
     });
 
     it("should send an event if the page has a data-journey tag on another tag", function () {
@@ -45,7 +45,7 @@ describe("stageprompt", function () {
 
       GOVUK.performance.stageprompt.setup(analyticsCallback);
 
-      expect(analyticsCallback).toHaveBeenCalledWith("test-journey:nextStep");
+      expect(analyticsCallback).toHaveBeenCalledWith("test-journey", "nextStep");
     });
 
     it("should send one event if the page has multiple elements with data-journey attribute", function () {
@@ -57,7 +57,46 @@ describe("stageprompt", function () {
       expect(analyticsCallback.callCount).toBe(1);
     });
 
-  })
+  });
+
+  describe("callback arguments", function() {
+
+    var analyticsCallback;
+
+    beforeEach(function () {
+      analyticsCallback = jasmine.createSpy();
+      $("<div id='sandbox'></div>").appendTo('body');
+    });
+
+    afterEach(function () {
+      $('#sandbox').remove();
+      $('[data-journey]').removeAttr('data-journey');
+    });
+
+    it("should pass action parts as separate arguments to the callback", function() {
+      $('#sandbox').attr('data-journey', 'part-1:part-2');
+
+      GOVUK.performance.stageprompt.setup(analyticsCallback);
+
+      expect(analyticsCallback).toHaveBeenCalledWith("part-1", "part-2");
+    });
+
+    it("should pass a single-part action as one argument", function() {
+      $('#sandbox').attr('data-journey', 'single-part');
+
+      GOVUK.performance.stageprompt.setup(analyticsCallback);
+
+      expect(analyticsCallback).toHaveBeenCalledWith("single-part");
+    });
+
+    it("should pass at most three arguments to the callback", function() {
+      $('#sandbox').attr('data-journey', 'part-1:part-2:part-3:additional-content');
+
+      GOVUK.performance.stageprompt.setup(analyticsCallback);
+
+      expect(analyticsCallback).toHaveBeenCalledWith("part-1", "part-2", "part-3:additional-content");
+    });
+  });
   
   describe("sending events for helper tags", function () {
     beforeEach(function () {

--- a/spec/javascripts/stagepromptSpec.js
+++ b/spec/javascripts/stagepromptSpec.js
@@ -114,7 +114,7 @@ describe("stageprompt", function () {
       
       $('#sandbox').click();
       
-      expect(analyticsCallback).toHaveBeenCalledWith("test-journey:stuff:help");
+      expect(analyticsCallback).toHaveBeenCalledWith("test-journey", "stuff", "help");
     });
     
     it("should send events for multiple help elements on the same page", function () {


### PR DESCRIPTION
- journey attribute values are split in parts, using ":" as separator, and the parts are passed as separate arguments to the callback
- GA callback uses the arguments as category, event and label
- the attribute to instrument click actions is now called data-journey-click 
