### PR TITLE
Add support for GA Universal

### DIFF
--- a/script/stageprompt.js
+++ b/script/stageprompt.js
@@ -59,5 +59,9 @@ GOVUK.performance.stageprompt = (function () {
 }());
 
 GOVUK.performance.sendGoogleAnalyticsEvent = function (category, event, label) {
-  _gaq.push(['_trackEvent', category, event, label, undefined, true]);
+  if (window.ga && typeof(window.ga) === 'function') {
+    ga('send', 'event', category, event, label);
+  } else {
+    _gaq.push(['_trackEvent', category, event, label, undefined, true]);
+  }
 };

--- a/spec/javascripts/analyticsCallbacksSpec.js
+++ b/spec/javascripts/analyticsCallbacksSpec.js
@@ -1,41 +1,72 @@
-describe("Google Analytics callback", function () {
+describe("Analytics callback", function () {
 
-  beforeEach(function () {
-    _gaq = { push: function() {} };
-    spyOn(_gaq, 'push');
-  });
+  describe("Google Analytics", function () {
+    beforeEach(function () {
+      _gaq = { push: function() {} };
+      spyOn(_gaq, 'push');
+    });
 
-  it("should push an event onto the google analytics que", function () {
-    GOVUK.performance.sendGoogleAnalyticsEvent('test');
+    it("should push an event onto the google analytics que", function () {
+      GOVUK.performance.sendGoogleAnalyticsEvent('test');
+      
+      expect(_gaq.push).toHaveBeenCalled();
+      expect(method(_gaq.push.argsForCall)).toEqual('_trackEvent');
+    });
+
+    it("should use arguments as category, event, label", function() {
+      GOVUK.performance.sendGoogleAnalyticsEvent('arg-1', 'arg-2', 'arg-3');
+
+      expect(_gaq.push).toHaveBeenCalled();
+      expect(category(_gaq.push.argsForCall)).toEqual('arg-1');
+      expect(action(_gaq.push.argsForCall)).toEqual('arg-2');
+      expect(label(_gaq.push.argsForCall)).toEqual('arg-3');
+    });
     
-    expect(_gaq.push).toHaveBeenCalled();
-    expect(method(_gaq.push.argsForCall)).toEqual('_trackEvent');
-  });
+    it("should use sensible default values... eg. non interaction events so as not to mess with bounce rate", function () {
+      GOVUK.performance.sendGoogleAnalyticsEvent('test event')
 
-  it("should use arguments as category, event, label", function() {
-    GOVUK.performance.sendGoogleAnalyticsEvent('arg-1', 'arg-2', 'arg-3');
+      expect(category(_gaq.push.argsForCall)).toEqual('test event');
+      expect(action(_gaq.push.argsForCall)).toEqual(undefined);
+      expect(label(_gaq.push.argsForCall)).toBe(undefined);
+      expect(value(_gaq.push.argsForCall)).toBe(undefined);
+      expect(nonInteraction(_gaq.push.argsForCall)).toEqual(true);
+    })
 
-    expect(_gaq.push).toHaveBeenCalled();
-    expect(category(_gaq.push.argsForCall)).toEqual('arg-1');
-    expect(action(_gaq.push.argsForCall)).toEqual('arg-2');
-    expect(label(_gaq.push.argsForCall)).toEqual('arg-3');
-  });
+    function method(args)         { return args[0][0][0]; }
+    function category(args)       { return args[0][0][1]; }
+    function action(args)         { return args[0][0][2]; }
+    function label(args)          { return args[0][0][3]; }
+    function value(args)          { return args[0][0][4]; }
+    function nonInteraction(args) { return args[0][0][5]; }
   
-  it("should use sensible default values... eg. non interaction events so as not to mess with bounce rate", function () {
-    GOVUK.performance.sendGoogleAnalyticsEvent('test event')
+    describe("Universal", function () {
+      beforeEach(function () {
+        window.ga = jasmine.createSpy();
+      });
 
-    expect(category(_gaq.push.argsForCall)).toEqual('test event');
-    expect(action(_gaq.push.argsForCall)).toEqual(undefined);
-    expect(label(_gaq.push.argsForCall)).toBe(undefined);
-    expect(value(_gaq.push.argsForCall)).toBe(undefined);
-    expect(nonInteraction(_gaq.push.argsForCall)).toEqual(true);
-  })
+      afterEach(function () {
+        window.ga = undefined;
+      });
 
-  function method(args)         { return args[0][0][0]; }
-  function category(args)       { return args[0][0][1]; }
-  function action(args)         { return args[0][0][2]; }
-  function label(args)          { return args[0][0][3]; }
-  function value(args)          { return args[0][0][4]; }
-  function nonInteraction(args) { return args[0][0][5]; }
+      it("should push an event to ga", function () {
+        GOVUK.performance.sendGoogleAnalyticsEvent("test");
+
+        expect(_gaq.push).not.toHaveBeenCalled();
+        expect(window.ga).toHaveBeenCalled();
+      });
+
+      it("should use arguments as category, event, label", function () {
+        GOVUK.performance.sendGoogleAnalyticsEvent('arg-1', 'arg-2', 'arg-3');
+
+        expect(window.ga).toHaveBeenCalled();
+        expect(window.ga.argsForCall[0][0]).toEqual('send');
+        expect(window.ga.argsForCall[0][1]).toEqual('event');
+        expect(window.ga.argsForCall[0][2]).toEqual('arg-1');
+        expect(window.ga.argsForCall[0][3]).toEqual('arg-2');
+        expect(window.ga.argsForCall[0][4]).toEqual('arg-3');
+      });
+    });
+  });
+
 
 });

--- a/spec/javascripts/stagepromptSpec.js
+++ b/spec/javascripts/stagepromptSpec.js
@@ -154,7 +154,7 @@ describe("stageprompt", function () {
     
     it("should get set up to send events to google analytics", function () {
       $('#sandbox').append('<div id="box" data-journey="thisIsATest"></div>');
-      
+
       GOVUK.performance.stageprompt.setupForGoogleAnalytics();
       
       expect(_gaq.push).toHaveBeenCalled();


### PR DESCRIPTION
Google Analytics Universal provides a function `ga` that sends all
communication to Google Analytics. The `sendGoogleAnalyticsEvent`
function now checks if the `ga` function exists and if it does, uses it.
